### PR TITLE
Added initial support for a subset of the better pdf syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ rect: W(0.069), H(0.113), W(0.861), H(0.337)
 
 Notice this field is not compatible with `text` field.
 
-### 1.3 File Front Matter
+### 1.2 File Front Matter
 
 You can overwrite above default value by write a front matter in the front of your note file.
 ```markdown
@@ -139,3 +139,26 @@ In the end, your notes should look like the following:
 
 ![advance usage](doc/advance.png)
 
+
+### 1.4 Better PDF Compatibility
+This plugin is compatible with a subset of the features [better-pdf](https://github.com/MSzturc/obsidian-better-pdf-plugin) offers.
+
+If you wish to display your old better-pdf notes, you can do so by enabling the "Support Better PDF Code Blocks" setting in the plugin settings.
+
+More information on the better-pdf syntax can be found [here](https://github.com/MSzturc/obsidian-better-pdf-plugin#syntax).
+
+It is not recommended that you continue to use the better-pdf syntax, as it is not guaranteed to be compatible with future versions of Slide Note.
+Try to migrate to the new syntax as soon as possible.
+
+While using the better-pdf syntax, some slide note features won't be available.
+
+| Better PDF Field Name | Supported by Slide Note                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| url                | ⚠️Partial, name.pdf subfolder/name.pdf and "[[filename.pdf]]" are supported, urls aren't supported |
+| link               | ❌                                                                                                 |
+| page               | ✅                                                                                                 |
+| range              | ✅                                                                                                 |
+| scale              | ✅                                                                                                 |
+| fit                | ❌                                                                                                 |
+| rotation           | ✅                                                                                                 |
+| rect               | ✅                                                                                                 |

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export class SlideNoteSettings {
 	allow_annotations: boolean = false;
 	default_text: boolean = false;
 	default_dpi: number = 1;
+	support_better_pdf: boolean = false;
 }
 
 export class SlideNoteSettingsTab extends PluginSettingTab {
@@ -48,6 +49,15 @@ export class SlideNoteSettingsTab extends PluginSettingTab {
 					this.plugin.settings.default_dpi = parseInt(value);
 					this.plugin.saveSettings();
 				}));
-
+		
+		new Setting(containerEl)
+			.setName("Support Better PDF Code Blocks")
+			.setDesc("Whether better-pdf code blocks are supported. If you previously used better-pdf, turn it on to use your legacy code blocks. Please note that you should start using slide-note code blocks as soon as possible.")
+			.addToggle(toggle => toggle.setValue(this.plugin.settings.support_better_pdf)
+				.onChange((value) => {
+					this.plugin.settings.support_better_pdf = value;
+					this.plugin.saveSettings();
+				}
+			));
 	}
 }


### PR DESCRIPTION
This pull request aims to help out people who have a bunch of better-pdf codeblocks in their vault and can't use the [better-pdf plugin](https://github.com/MSzturc/obsidian-better-pdf-plugin) since it hasn't been update for the lates obsidian version.
An option is added to support the better pdf syntax. This option defaults to off. 
After it is enabled, better pdf syntax is read and the pdf/pages of it are displayed.

This has been proposed in #7 