### PR TITLE
Fixes #16: Fix memory leak by destroying loaded documents

### DIFF
--- a/src/pdfblock/renderer.ts
+++ b/src/pdfblock/renderer.ts
@@ -50,26 +50,30 @@ export class PDFBlockRenderer extends MarkdownRenderChild {
 
 		const pos = hook.getBoundingClientRect().bottom;
 
-		if (pos != 0 && pos <= window.innerHeight) {
-			this.render();
-		}
-		else {
-			const delay = window.setInterval(
-				() => {
-					clearInterval(delay);
-					this.render();
-				},
-				(this.params.page[0] % 15 + 1) * 5000
-			)
-
-			const renderCallBack = function () {
-				if (hook.getBoundingClientRect().bottom != 0) {
-					clearInterval(delay);
-					this.render();
-				}
+		if (this.settings.lazy_load) {
+			if (pos != 0 && pos <= window.innerHeight) {
+				this.render();
 			}
-			document.addEventListener("wheel", renderCallBack.bind(this));
-			document.addEventListener("touchmove",  renderCallBack.bind(this));
+			else {
+				const delay = window.setInterval(
+					() => {
+						clearInterval(delay);
+						this.render();
+					},
+					(this.params.page[0] % 15 + 1) * 5000
+				)
+	
+				const renderCallBack = function () {
+					if (hook.getBoundingClientRect().bottom != 0) {
+						clearInterval(delay);
+						this.render();
+					}
+				}
+				document.addEventListener("wheel", renderCallBack.bind(this));
+				document.addEventListener("touchmove",  renderCallBack.bind(this));
+			}
+		} else {
+			this.render();
 		}
 	}
 

--- a/src/pdfblock/renderer.ts
+++ b/src/pdfblock/renderer.ts
@@ -9,6 +9,7 @@ export class PDFBlockRenderer extends MarkdownRenderChild {
 	sourcePath: string
 	settings: SlideNoteSettings
 	cache: FileCache
+	pdfdocument: any
 	public constructor(
 		el: HTMLElement,
 		params: PDFBlockParameters,
@@ -34,6 +35,11 @@ export class PDFBlockRenderer extends MarkdownRenderChild {
 				}
 			})
 		)
+		
+	}
+
+	onunload(){
+		this.pdfdocument.destroy();
 	}
 
 	async init() {
@@ -73,18 +79,18 @@ export class PDFBlockRenderer extends MarkdownRenderChild {
 			try {
 				const buffer = await this.cache.get(this.params.file);
 				const pdfjs = await loadPdfJs();
-				const pdfdocument = await pdfjs.getDocument(buffer).promise;
+				this.pdfdocument = await pdfjs.getDocument(buffer).promise;
 
 				if (this.params.page.includes(0)) {
 					this.params.page = Array.from(
-						{length: pdfdocument.numPages},
+						{length: this.pdfdocument.numPages},
 						(_, i) => i + 1
 					);
 				}
 
 				for (const pageNumber of this.params.page) {
 
-					const page = await pdfdocument.getPage(pageNumber);
+					const page = await this.pdfdocument.getPage(pageNumber);
 					const host = this.el.createEl("div");
 					host.addClass("slide-note-pdfblock");
 					host.style.position = "relative";

--- a/src/pdfblock/renderer.ts
+++ b/src/pdfblock/renderer.ts
@@ -39,7 +39,7 @@ export class PDFBlockRenderer extends MarkdownRenderChild {
 	}
 
 	onunload(){
-		this.pdfdocument.destroy();
+		this.pdfdocument?.destroy();
 	}
 
 	async init() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export class SlideNoteSettings {
 	default_text: boolean = false;
 	default_dpi: number = 1;
 	support_better_pdf: boolean = false;
+	lazy_load: boolean = true;
 }
 
 export class SlideNoteSettingsTab extends PluginSettingTab {
@@ -57,7 +58,16 @@ export class SlideNoteSettingsTab extends PluginSettingTab {
 				.onChange((value) => {
 					this.plugin.settings.support_better_pdf = value;
 					this.plugin.saveSettings();
-				}
-			));
+				}));
+		
+		new Setting(containerEl)
+		.setName("Lazy Load Slide Note Blocks")
+		.setDesc("Delay rendering of slide-note code blocks until they are visible on screen. This can improve performance for large documents by reducing initial load time. DISABLE for printing your markdown file to PDF!")
+		.addToggle(toggle => toggle.setValue(this.plugin.settings.lazy_load)
+			.onChange((value) => {
+				this.plugin.settings.lazy_load = value;
+				this.plugin.saveSettings();
+			}));
+		
 	}
 }


### PR DESCRIPTION
PDF.js workers remain active if documents aren't destroyed.
Provided (quick & dirty) fix: Call pdfdocument.destroy() when unloading the PDFBlockRenderer.